### PR TITLE
feat: add temperatureOffset, humidityOffset and percentage-based offset config options

### DIFF
--- a/MMM-DHT-Sensor.js
+++ b/MMM-DHT-Sensor.js
@@ -15,6 +15,10 @@ Module.register("MMM-DHT-Sensor", {
 		debug: false,
 		sensorPin: 2,
 		sensorType: 22,
+		temperatureOffset: 0,
+		temperatureOffsetPercent: 0,
+		humidityOffset: 0,
+		humidityOffsetPercent: 0,
 	},
 
 	start: function () {
@@ -77,8 +81,8 @@ Module.register("MMM-DHT-Sensor", {
 		}
 
 		const roundToTwo = (value) => Math.round(value * 100) / 100;
-		const celsius = roundToTwo(rawTemp);
-		const humidity = roundToTwo(rawHumidity);
+		const celsius = roundToTwo(rawTemp * (1 + this.config.temperatureOffsetPercent / 100) + this.config.temperatureOffset);
+		const humidity = roundToTwo(rawHumidity * (1 + this.config.humidityOffsetPercent / 100) + this.config.humidityOffset);
 		this.temperature =
 			this.config.units === "imperial"
 				? roundToTwo((celsius * 9) / 5 + 32)


### PR DESCRIPTION
## Problem

DHT sensors placed inside a MagicMirror enclosure are often affected 
by the heat generated by the display and electronics, resulting in 
inaccurate temperature and humidity readings.

## Solution

Add four optional config parameters to compensate for sensor drift:

- `temperatureOffset` (default: `0`): fixed value added to the raw temperature reading
- `temperatureOffsetPercent` (default: `0`): percentage applied to the raw temperature reading
- `humidityOffset` (default: `0`): fixed value added to the raw humidity reading
- `humidityOffsetPercent` (default: `0`): percentage applied to the raw humidity reading

Both fixed and percentage offsets can be combined:
`final value = raw * (1 + offsetPercent / 100) + offset`

## Usage

```js
{
    module: "MMM-DHT-Sensor",
    config: {
        sensorPin: 2,
        sensorType: 22,
        temperatureOffset: -3,       // fixed offset: -3°C
        temperatureOffsetPercent: 0, // percentage offset
        humidityOffset: 0,
        humidityOffsetPercent: -5,   // sensor reads 5% too high
    }
}
```

## Changes

- `MMM-DHT-Sensor.js`: added four offset options to defaults and applied 
  them in `processSensorData()`